### PR TITLE
Add Google Oauth redirect URI

### DIFF
--- a/rainbow/rainbow_project/settings.py
+++ b/rainbow/rainbow_project/settings.py
@@ -237,6 +237,7 @@ DJOSER = {
         "https://rainbowchallenge/auth/o/google-oauth2/",
         "http://127.0.0.1:8000/auth/o/google-oauth2/",
         "https://rainbowchallenge.lt/auth/users/me/",
+        "https://rainbowchallenge.lt/api/user/oauth_token/"
     ]
 }
 

--- a/rainbow/rainbow_project/settings_dev.py
+++ b/rainbow/rainbow_project/settings_dev.py
@@ -24,6 +24,7 @@ DJOSER = {
         "https://rainbowchallenge/auth/o/google-oauth2/",
         "http://127.0.0.1:8000/auth/o/google-oauth2/",
         "https://rainbowchallenge.lt/auth/users/me/",
+        "https://rainbowchallenge.lt/api/user/oauth_token/"
     ]
 }
 


### PR DESCRIPTION
This change is intended to fix Google Oauth redirect URIs to accomodate the new API route /api/user/oauth_token/